### PR TITLE
added some changes on t_map struct and also in other functions

### DIFF
--- a/includes/Cub3d.h
+++ b/includes/Cub3d.h
@@ -6,7 +6,7 @@
 /*   By: rafael <rafael@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/15 15:52:17 by raamorim          #+#    #+#             */
-/*   Updated: 2025/11/10 10:36:08 by htrindad         ###   ########.fr       */
+/*   Updated: 2025/11/10 17:33:13 by rafael           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,139 +55,142 @@ typedef uint32_t	t_rgb;
 
 typedef struct s_file
 {
-	int	fd;
-}	t_file;
+	int				fd;
+}					t_file;
 
 typedef struct s_img
 {
-	void	*img;
-	char	*pixel_ptr;
-	int		bits_pixel;
-	int		end;
-	int		line_len;
-}	t_img;
+	void			*img;
+	char			*pixel_ptr;
+	int				bits_pixel;
+	int				end;
+	int				line_len;
+}					t_img;
 
 typedef struct s_mlx
 {
-	void		*mlx;
-	void		*win;
-	t_img		img;
-}				t_mlx;
+	void			*mlx;
+	void			*win;
+	t_img			img;
+}					t_mlx;
 
 typedef struct s_map
 {
-	char		**buffer;
-	char		**map;
-	char		**temp_map;
-	char		*north;
-	char		*south;
-	char		*west;
-	char		*east;
-	char		*floor;
-	char		*ceiling;
-	int			height;
-}				t_map;
+	char			**buffer;
+	char			**map;
+	char			**temp_map;
+	char			*north;
+	char			*south;
+	char			*west;
+	char			*east;
+	char			*floor;
+	char			*ceiling;
+	int				height;
+	t_rgb			rgb_floor;
+	t_rgb			rgb_ceiling;
+}					t_map;
 
 typedef struct s_player
 {
-	float		x;
-	float		y;
-	float		dir_x;
-	float		dir_y;
-	float		plane_x;
-	float		plane_y;
-}				t_player;
+	float			x;
+	float			y;
+	float			dir_x;
+	float			dir_y;
+	float			plane_x;
+	float			plane_y;
+}					t_player;
 
 typedef struct s_data
 {
-	t_img		img;
-	t_mlx		mlx;
-	t_player	player;
-	t_map		map;
-	t_file		file;
-}				t_data;
+	t_img			img;
+	t_mlx			mlx;
+	t_player		player;
+	t_map			map;
+	t_file			file;
+}					t_data;
 
 // src/textures/set_textures.c
-bool			check_load_textures(t_map *map);
-bool			set_texture(char *line, t_map *map);
+bool				check_load_textures(t_map *map);
+bool				set_texture(char *line, t_map *map);
 
 // src/init/init.c
-void			init_struct(t_data *data);
+void				init_struct(t_data *data);
 
 // src/mlx/init_mlx.c
-void			init_mlx(t_data *data);
+void				init_mlx(t_data *data);
 
 // src/erros/errors.c
-void			exit_error(t_data *data, char *str);
-void			free_all(t_data *data);
+void				exit_error(t_data *data, char *str);
+void				free_all(t_data *data);
 
 // src//hooks/keys.c
-int				handle_keypress(int key, t_data *data);
-int				press_x(t_data *data);
+int					handle_keypress(int key, t_data *data);
+int					press_x(t_data *data);
 
 // src/parsing/file/check_file.c
-void			check_map_name(char *file_name);
+void				check_map_name(char *file_name);
 
 // src//parsing/map/check_map/check_map.c
-bool			check_map(t_map *map);
-bool			check_valid_chars(t_map *map);
-bool			check_player(t_map *map);
-void			set_bool(t_map *map);
-bool			alloc_temp_map(t_map *map);
+bool				check_map(t_map *map);
+bool				check_valid_chars(t_map *map);
+bool				check_player(t_map *map);
+void				set_bool(t_map *map);
+bool				alloc_temp_map(t_map *map);
 
 // src//parsing/map/check_map/check_map_utils.c
-bool			check_surroundings(t_map *map);
-bool			flood_fill_map(t_map *map, int i, int j);
-bool			is_valid(char *arr, char c);
-bool			verify_texture(char *path);
-bool			check_textures(t_map *map);
-bool			check_rgb(char *rgb);
-bool			check_range(int nb);
+bool				check_surroundings(t_map *map);
+bool				flood_fill_map(t_map *map, int i, int j);
+bool				is_valid(char *arr, char c);
+bool				verify_texture(char *path);
+bool				check_textures(t_map *map);
+bool				check_rgb(char *rgb);
+bool				check_range(int nb);
 
 // src/parsing/map/get_map/get_map.c
-void			get_lines(t_data *data, char *file_name);
-void			start_buffer(t_data *data);
-int				alloc_buffer(t_data *data, int *i);
-void			get_map(char *file_name, t_data *data);
+void				get_lines(t_data *data, char *file_name);
+void				start_buffer(t_data *data);
+int					alloc_buffer(t_data *data, int *i);
+void				get_map(char *file_name, t_data *data);
 
 // src/parsing/get_map/parse_map.c
-bool			parse_map(t_data *data);
-bool			set_map(t_map *map, int i);
-bool			alloc_map(t_map *map, int *i);
+bool				parse_map(t_data *data);
+bool				set_map(t_map *map, int i);
+bool				alloc_map(t_map *map, int *i);
 
 // src/parsing/player/init_player.c
-void			init_player(t_data *data);
-void			set_player_direction(t_player *p, char dir);
+void				init_player(t_data *data);
+void				set_player_direction(t_player *p, char dir);
 
 // src/parsing/map/init_map.c
-int				init_map(char *file, t_data *data);
+int					init_map(char *file, t_data *data);
+bool				set_fc_rgb(t_data *data);
 
 // src/parsing/player/init_player.c
-void			init_player(t_data *data);
-void			set_player_direction(t_player *player, char dir);
+void				init_player(t_data *data);
+void				set_player_direction(t_player *player, char dir);
 
 // src/player/move.c
-bool			is_wall(t_map *map, float y, float x);
-void			move_forward(t_data *data);
-void			move_backward(t_data *data);
-void			move_left(t_data *data);
-void			move_right(t_data *data);
+bool				is_wall(t_map *map, float y, float x);
+void				move_forward(t_data *data);
+void				move_backward(t_data *data);
+void				move_left(t_data *data);
+void				move_right(t_data *data);
 
 // src/utils/utils.c
-void			close_fds(int i);
-size_t			ft_stralen(char **arr);
-void			free_arr(char **arr);
-char			*replace_tabs(char *line);
-void			free_map(t_map *map);
-void			free_file(t_file *file);
-void			free_mlx(t_mlx *mlx);
-t_rgb			ft_rgb(uint8_t r, uint8_t g, uint8_t b);
-uint8_t			ft_atob(char *str);
+void				close_fds(int i);
+size_t				ft_stralen(char **arr);
+void				free_arr(char **arr);
+char				*replace_tabs(char *line);
+void				free_map(t_map *map);
+void				free_file(t_file *file);
+void				free_mlx(t_mlx *mlx);
+t_rgb				ft_rgb(uint8_t r, uint8_t g, uint8_t b);
+uint8_t				ft_atob(char *str);
 
 // src/render/color.c
-t_rgb			set_rgb(char *strrgb, t_data *data);
+t_rgb				set_rgb(char *strrgb, t_data *data);
 
 // src/render/render.c
-int				render(t_data *data);
+int					render(t_data *data);
 
 #endif

--- a/src/parsing/map/init_map.c
+++ b/src/parsing/map/init_map.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   init_map.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: raamorim <raamorim@student.42.fr>          +#+  +:+       +#+        */
+/*   By: rafael <rafael@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/22 16:11:03 by raamorim          #+#    #+#             */
-/*   Updated: 2025/11/07 17:28:11 by raamorim         ###   ########.fr       */
+/*   Updated: 2025/11/10 17:36:43 by rafael           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,31 @@ int	init_map(char *file, t_data *data)
 	get_map(file, data);
 	if (check_map(&data->map) == false)
 		exit_error(data, "ERROR:\ncheck_map");
+	if (set_fc_rgb(data) == false)
+		exit_error(data, "ERROR:\nset_fc_rgb");
 	init_player(data);	
 	return (1);
+}
+
+bool set_fc_rgb(t_data *data)
+{
+	if (!data)
+		return (false);
+	data->map.rgb_ceiling = set_rgb(data->map.ceiling, data);
+	if (!data->map.rgb_ceiling)
+		return (false);
+	if (data->map.ceiling)
+	{
+		free(data->map.ceiling);
+		data->map.ceiling = NULL;
+	}
+	data->map.rgb_floor = set_rgb(data->map.floor, data);
+	if (!data->map.rgb_floor)
+		return (false);
+	if (data->map.floor)
+	{
+		free(data->map.floor);
+		data->map.floor = NULL;
+	}
+	return (true);
 }

--- a/src/parsing/player/init_player.c
+++ b/src/parsing/player/init_player.c
@@ -6,7 +6,7 @@
 /*   By: rafael <rafael@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/04 00:07:28 by rafael            #+#    #+#             */
-/*   Updated: 2025/11/04 02:58:19 by rafael           ###   ########.fr       */
+/*   Updated: 2025/11/10 17:34:57 by rafael           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,5 @@ void	init_player(t_data *data)
 		}
 		y++;
 	}
-	ft_putendl_fd("ERROR:\nplayer not found in map", 2);
-	exit(1);
+	exit_error(data, "ERROR:\nplayer not found in map");
 }

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   render.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: htrindad <htrindad@student.42lisboa.com>   +#+  +:+       +#+        */
+/*   By: rafael <rafael@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/08 17:38:38 by htrindad          #+#    #+#             */
-/*   Updated: 2025/11/10 10:45:47 by htrindad         ###   ########.fr       */
+/*   Updated: 2025/11/10 17:32:16 by rafael           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,15 +38,11 @@ static inline void	paint_bg(t_rgb floor, t_rgb ceiling, t_img *img)
 
 static void	set_fc(t_data *data)
 {
-	t_rgb	floor;
-	t_rgb	ceiling;
 	t_img	*img;
-
-	floor = set_rgb(data->map.floor, data);
-	ceiling = set_rgb(data->map.ceiling, data);
+	
 	img = &data->mlx.img;
 	img->pixel_ptr = mlx_get_data_addr(img->img, &img->bits_pixel, &img->line_len, &img->end);
-	paint_bg(floor, ceiling, img);
+	paint_bg(data->map.rgb_floor, data->map.rgb_ceiling, img);
 }
 
 int	render(t_data *data)


### PR DESCRIPTION
Added 2 new` t_rgb` fields in `t_map` struct to store the rgb values of` map->ceiling` and `map->floor`

Created a new function called `set_fc_rgb` to set the rgb values os `floor` and `ceiling` in this new `t_rgb` fields of `t_map` struct.
In this function after setting the colors to rgb, we check if everything worked well, if everything is ok we free `map->ceiling/floor`  and set them to `NULL` because if we don't, in the end of the program we would have a double free after we call `free_map`

I also added a `set_fc_rgb` call in function `init_map` to set the rgb colours
```
if (set_fc_rgb(data) == false)
		exit_error(data, "ERROR:\nset_fc_rgb");
```


In the function `init_player `, I changed this 2 lines of code: 
```
ft_putendl_fd("ERROR:\nplayer not found in map", 2);
exit(1);
```

for this one:
`exit_error(data, "ERROR:\nplayer not found in map");`

Reason: It does the same thing, we save lines and it's more explicit.


Also removed this 4 lines in `set_fc` function because with the new` t_rgb` fields of the` t_map` struct, we don't need it anymore
```
t_rgb	floor;
t_rgb	ceiling;

floor = set_rgb(data->map.floor, data);
ceiling = set_rgb(data->map.ceiling, data);
```

and changed in the same fuction the line:
`paint_bg(floor, ceiling, img);`

to :
`paint_bg(data->map.rgb_floor, data->map.rgb_ceiling, img);`